### PR TITLE
Add global hot-key

### DIFF
--- a/Codex/Codex/CodexApp.swift
+++ b/Codex/Codex/CodexApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import Carbon
 
 @main
 struct CodexApp: App {
@@ -15,6 +16,8 @@ struct CodexApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private let popover = NSPopover()
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
@@ -26,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(rootView: ContentView())
+        registerHotKey()
     }
 
     @objc private func togglePopover() {
@@ -35,5 +39,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
+    }
+
+    private func registerHotKey() {
+        var hotKeyID = EventHotKeyID(signature: 0x43445831, id: 1)
+        let eventSpec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(GetApplicationEventTarget(), { _, event, userData in
+            var hkID = EventHotKeyID()
+            GetEventParameter(event, EventParamName(kEventParamDirectObject), EventParamType(typeEventHotKeyID), nil, MemoryLayout<EventHotKeyID>.size, nil, &hkID)
+            if hkID.id == 1, let ptr = userData {
+                Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue().togglePopover()
+            }
+            return noErr
+        }, 1, [eventSpec], UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()), &eventHandler)
+        RegisterEventHotKey(UInt32(kVK_ANSI_T), UInt32(cmdKey | optionKey), hotKeyID, GetApplicationEventTarget(), 0, &hotKeyRef)
     }
 }


### PR DESCRIPTION
## Summary
- register global ⌥⌘T with minimal Carbon code
- toggle popover when the hot-key is triggered

## Testing
- `git status --short`
