### PR TITLE
Update build for Swift 6.1

### DIFF
--- a/Codex.xcodeproj/project.pbxproj
+++ b/Codex.xcodeproj/project.pbxproj
@@ -93,12 +93,13 @@
             isa = XCBuildConfiguration;
             buildSettings = {
                 PRODUCT_NAME = "$(TARGET_NAME)";
-                SWIFT_VERSION = 6.0;
+                SWIFT_VERSION = 6.1;
+                SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
                 CODE_SIGN_IDENTITY = "-";
                 CODE_SIGNING_REQUIRED = NO;
                 CODE_SIGNING_ALLOWED = NO;
                 DEVELOPMENT_TEAM = "";
-                MACOSX_DEPLOYMENT_TARGET = 14.0;
+                MACOSX_DEPLOYMENT_TARGET = 15.5;
                 TARGETED_DEVICE_FAMILY = "1,2";
                 INFOPLIST_FILE = Info.plist;
             };
@@ -108,12 +109,13 @@
             isa = XCBuildConfiguration;
             buildSettings = {
                 PRODUCT_NAME = "$(TARGET_NAME)";
-                SWIFT_VERSION = 6.0;
+                SWIFT_VERSION = 6.1;
+                SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
                 CODE_SIGN_IDENTITY = "-";
                 CODE_SIGNING_REQUIRED = NO;
                 CODE_SIGNING_ALLOWED = NO;
                 DEVELOPMENT_TEAM = "";
-                MACOSX_DEPLOYMENT_TARGET = 14.0;
+                MACOSX_DEPLOYMENT_TARGET = 15.5;
                 TARGETED_DEVICE_FAMILY = "1,2";
                 INFOPLIST_FILE = Info.plist;
             };

--- a/Codex/Info.plist
+++ b/Codex/Info.plist
@@ -17,6 +17,6 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>15.5</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- build Codex with Swift 6.1
- bump macOS deployment to 15.5
- enforce warnings-as-errors

## Testing
- `swift --version`
