### PR TITLE
Add SwiftPM support and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-latest-xlarge
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
+      - name: Build Release
+        run: |
+          xcodebuild -project Codex.xcodeproj -scheme Codex -configuration Release -derivedDataPath DerivedData CODE_SIGN_IDENTITY="${{ secrets.CODE_SIGN_IDENTITY }}" DEVELOPMENT_TEAM="${{ secrets.DEVELOPMENT_TEAM }}" | xcpretty
+      - name: Create DMG
+        run: |
+          hdiutil create Codex.dmg -volname Codex -srcfolder DerivedData/Build/Products/Release/Codex.app
+      - name: Notarize
+        run: |
+          xcrun notarytool submit Codex.dmg --apple-id ${{ secrets.APPLE_ID }} --team-id ${{ secrets.TEAM_ID }} --password ${{ secrets.APP_SPECIFIC_PASSWORD }} --wait
+      - name: Staple
+        run: xcrun stapler staple Codex.dmg
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Codex.dmg
+          path: Codex.dmg
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "Codex",
+    platforms: [
+        .macOS(.v15)
+    ],
+    products: [
+        .executable(name: "Codex", targets: ["Codex"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "Codex",
+            path: "Codex",
+            resources: [.copy("Info.plist")]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Codex
 
 ## Build Instructions
+### Xcode
 1. Open **Codex.xcodeproj** in Xcode 16.
 2. Select the *Codex* scheme.
 3. Build or Run with `⌘B` or `⌘R`. The project has no external dependencies and should compile cleanly.
+
+### Swift Package Manager
+Run `swift build -c release` from the repository root. The package uses Swift 6.1 and targets macOS 15.5 or later.
 
 ## Using the App
 - The menu-bar icon shows your task list. Press **⌥⌘T** to toggle the window from anywhere.


### PR DESCRIPTION
## Summary
- add `Package.swift` for a SwiftPM build
- document SwiftPM build instructions
- provide GitHub Actions workflow for building and notarizing on macOS runners

## Testing
- `git log -1 --stat`
