### PR TITLE
Add appearance preference

### DIFF
--- a/Codex/Codex/CodexApp.swift
+++ b/Codex/Codex/CodexApp.swift
@@ -28,9 +28,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             button.target = self
         }
 
-        let content = NSHostingController(rootView: ContentView(updateTitle: { [weak self] title in
+        let scheme = UserDefaults.standard.string(forKey: "colorScheme") ?? "system"
+        let colorScheme: ColorScheme?
+        switch scheme {
+        case "light":
+            colorScheme = .light
+        case "dark":
+            colorScheme = .dark
+        default:
+            colorScheme = nil
+        }
+
+        let rootView = ContentView(updateTitle: { [weak self] title in
             self?.window?.title = title
-        }))
+        }).preferredColorScheme(colorScheme)
+
+        let content = NSHostingController(rootView: rootView)
         let defaultFrame = NSRect(x: 0, y: 0, width: 320, height: 440)
         window = NSWindow(contentRect: defaultFrame,
                           styleMask: [.titled, .closable, .resizable],

--- a/Codex/Codex/PreferencesView.swift
+++ b/Codex/Codex/PreferencesView.swift
@@ -4,6 +4,7 @@ import Carbon
 struct PreferencesView: View {
     @AppStorage("hotKeyKeyCode") private var keyCode: Int = Int(kVK_ANSI_T)
     @AppStorage("hotKeyModifiers") private var modifiers: Int = Int(cmdKey | optionKey)
+    @AppStorage("colorScheme") private var colorScheme: String = "system"
 
     var appDelegate: AppDelegate
 
@@ -47,6 +48,11 @@ struct PreferencesView: View {
             Toggle("Option (⌥)", isOn: modifierBinding(optionKey))
             Toggle("Shift (⇧)", isOn: modifierBinding(shiftKey))
             Toggle("Control (⌃)", isOn: modifierBinding(controlKey))
+            Picker("Appearance", selection: $colorScheme) {
+                Text("System").tag("system")
+                Text("Light").tag("light")
+                Text("Dark").tag("dark")
+            }
         }
         .padding(20)
         .onChange(of: keyCode) { _ in


### PR DESCRIPTION
## Summary
- allow users to pick a preferred appearance
- store selection in `@AppStorage("colorScheme")`
- read saved appearance in `CodexApp` and apply with `.preferredColorScheme()`

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*