### PR TITLE
Allow pop-up across spaces

### DIFF
--- a/Codex/Codex/CodexApp.swift
+++ b/Codex/Codex/CodexApp.swift
@@ -39,6 +39,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         window?.isReleasedWhenClosed = false
         window?.contentView = content.view
         window?.delegate = self
+        window?.level = .floating
+        window?.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
         if let frameString = UserDefaults.standard.string(forKey: "windowFrame") {
             window?.setFrame(NSRectFromString(frameString), display: false)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run `swift build -c release` from the repository root. The package uses Swift 6
 
 - The menu-bar icon shows your task list. Press **⌥⌘T** to toggle the window from anywhere.
 - When the window opens you see a list of Markdown files in `~/Documents/tasks`. Pick one to view its tasks.
-- The window can be resized like a normal macOS window.
+ - The window can be resized like a normal macOS window and floats above full-screen apps so it's always accessible.
 - Lines containing `[ ]` or `[x]` become interactive checkboxes. Checking or unchecking immediately writes the change back to the selected file.
 
  - Lines beginning with a dash (`-`) are displayed without the bullet for a cleaner list.


### PR DESCRIPTION
## Summary
- make the Codex window float above fullscreen apps by joining all spaces
- document floating window behavior in README

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*