### PR TITLE
Change hotkey default to ⇧⌘E

### DIFF
--- a/Codex/Codex/CodexApp.swift
+++ b/Codex/Codex/CodexApp.swift
@@ -80,7 +80,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func registerHotKey() {
         let code = UserDefaults.standard.integer(forKey: "hotKeyKeyCode")
         let mods = UserDefaults.standard.integer(forKey: "hotKeyModifiers")
-        registerHotKey(keyCode: UInt32(code == 0 ? Int(kVK_ANSI_T) : code), modifiers: UInt32(mods == 0 ? Int(cmdKey | optionKey) : mods))
+        registerHotKey(keyCode: UInt32(code == 0 ? Int(kVK_ANSI_E) : code), modifiers: UInt32(mods == 0 ? Int(cmdKey | shiftKey) : mods))
     }
 
     private func registerHotKey(keyCode: UInt32, modifiers: UInt32) {

--- a/Codex/Codex/PreferencesView.swift
+++ b/Codex/Codex/PreferencesView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import Carbon
 
 struct PreferencesView: View {
-    @AppStorage("hotKeyKeyCode") private var keyCode: Int = Int(kVK_ANSI_T)
-    @AppStorage("hotKeyModifiers") private var modifiers: Int = Int(cmdKey | optionKey)
+    @AppStorage("hotKeyKeyCode") private var keyCode: Int = Int(kVK_ANSI_E)
+    @AppStorage("hotKeyModifiers") private var modifiers: Int = Int(cmdKey | shiftKey)
 
     var appDelegate: AppDelegate
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Run `swift build -c release` from the repository root. The package uses Swift 6
 
 ## Using the App
 
-- The menu-bar icon shows your task list. Press **⌥⌘T** to toggle the window from anywhere.
+- The menu-bar icon shows your task list. Press **⇧⌘E** to toggle the window from anywhere.
 - When the window opens you see a list of Markdown files in `~/Documents/tasks`. Pick one to view its tasks.
 - The window can be resized like a normal macOS window.
 - Lines containing `[ ]` or `[x]` become interactive checkboxes. Checking or unchecking immediately writes the change back to the selected file.

--- a/READMESETUPAP.md
+++ b/READMESETUPAP.md
@@ -4,7 +4,7 @@ Role
 You are a veteran macOS developer who ships lean, native apps that feel instant on Apple-silicon Macs.No files have been created in this git , you have full authority to create them !
 Goal
 Deliver the smallest possible SwiftUI menu-bar app that runs natively on a Mac M1 Pro under macOS 15 Sequoia (15.5 or later).
-Global hot-key: ⌥ ⌘ T (configurable) toggles a drop-down window.
+Global hot-key: ⇧ ⌘ E (configurable) toggles a drop-down window.
 Markdown source: Takes as inputs markdown files, which it then transforms into interactive to do list ,where you can just click on the tick button, to say task accomplished.
 Every line containing [ ] is an unchecked task.
 Every line containing [x] is a checked task.


### PR DESCRIPTION
## Summary
- switch default key from `T` to `E`
- update user guide text and setup notes

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*