### PR TITLE
Add drag-and-drop reordering for tasks

### DIFF
--- a/Codex/Codex/ContentView.swift
+++ b/Codex/Codex/ContentView.swift
@@ -80,6 +80,7 @@ struct ContentView: View {
                                 .padding(.leading, CGFloat(task.indent) * 10)
                         }
                     }
+                    .onMove(perform: move)
                 }
                 .searchable(text: $searchText)
                 .listStyle(.inset)
@@ -136,5 +137,16 @@ struct ContentView: View {
             try? "".write(to: url, atomically: true, encoding: .utf8)
         }
         tasks = TaskParser.load(from: url)
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        guard searchText.isEmpty else { return }
+        tasks.move(fromOffsets: source, toOffset: destination)
+        for index in tasks.indices {
+            tasks[index].id = index
+        }
+        if let url = selectedFile {
+            TaskParser.save(tasks, to: url)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle drag reordering by applying `.onMove` to the task list
- update task IDs after move and save changes via `TaskParser.save`

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*