### PR TITLE
Fix preferences compile error

### DIFF
--- a/Codex/Codex/ContentView.swift
+++ b/Codex/Codex/ContentView.swift
@@ -70,7 +70,7 @@ struct ContentView: View {
                 if let current = currentTask,
                    let start = current.scheduledTime {
                     let remaining = max(0, start.addingTimeInterval(defaultDuration).timeIntervalSince(tick))
-                    Text("\u23F1 " + timeString(from: remaining))
+                    Text("\u{23F1} " + timeString(from: remaining))
                         .font(.subheadline)
                         .monospacedDigit()
 

--- a/Codex/Codex/PreferencesView.swift
+++ b/Codex/Codex/PreferencesView.swift
@@ -5,6 +5,7 @@ struct PreferencesView: View {
 
     @AppStorage("hotKeyKeyCode") private var keyCode: Int = Int(kVK_ANSI_E)
     @AppStorage("hotKeyModifiers") private var modifiers: Int = Int(cmdKey | shiftKey)
+    @AppStorage("colorScheme") private var colorScheme: String = "system"
 
 
     var appDelegate: AppDelegate


### PR DESCRIPTION
## Summary
- restore `colorScheme` setting in `PreferencesView`
- fix Unicode escape in `ContentView`

## Testing
- `swift --version`
- `swift build --product Codex -c debug --triple x86_64-apple-macosx13.0` *(fails: toolchain is invalid)*
