### PR TITLE
Fix compilation issues in SwiftUI views

### DIFF
--- a/Codex/Codex/ContentView.swift
+++ b/Codex/Codex/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @State private var taskFiles: [URL] = []
     @State private var selectedFile: URL?
     @State private var searchText = ""
+    @State private var newTaskText = ""
 
     @State private var tick = Date()
 
@@ -73,6 +74,7 @@ struct ContentView: View {
                     Text("\u{23F1} " + timeString(from: remaining))
                         .font(.subheadline)
                         .monospacedDigit()
+                }
 
                 HStack {
                     TextField("New Task", text: $newTaskText)
@@ -246,7 +248,6 @@ struct ContentView: View {
         let seconds = totalSeconds % 60
         return String(format: "%02d:%02d", minutes, seconds)
     }
-}
 
     private func move(from source: IndexSet, to destination: Int) {
         guard searchText.isEmpty else { return }
@@ -258,6 +259,5 @@ struct ContentView: View {
             TaskParser.save(tasks, to: url)
         }
     }
-
 }
 

--- a/Codex/Codex/Task.swift
+++ b/Codex/Codex/Task.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct Task: Identifiable {
-    let id: Int
+    var id: Int
     var line: String
     var isTask: Bool
     var isDone: Bool


### PR DESCRIPTION
## Summary
- define `newTaskText` state in `ContentView`
- close the conditional block for `currentTask`
- include move function within `ContentView` struct
- allow `Task.id` to be mutable

## Testing
- `swift build -c debug` *(fails: no such module `SwiftUI`)*